### PR TITLE
Fixed gatekeeper on sign-in route

### DIFF
--- a/blueprint-experiences/app/routers/endpoint.js
+++ b/blueprint-experiences/app/routers/endpoint.js
@@ -6,7 +6,7 @@ const { Router } = require ('@onehilltech/blueprint');
  */
 module.exports = Router.extend ({
   specification: {
-    '/gatekeeper': blueprint.mount ('@onehilltech/blueprint-gatekeeper:v1')
+    '/gatekeeper': blueprint.mount ('@onehilltech/blueprint-gatekeeper:v1'),
 
     // protecting the /v1 routes
     '/v1': {

--- a/blueprint-experiences/app/routers/v1.js
+++ b/blueprint-experiences/app/routers/v1.js
@@ -1,7 +1,10 @@
-const { cors } = require ('@onehilltech/blueprint-gatekeeper');
+const { Router } = require('@onehilltech/blueprint');
+const cors = require('cors');
 
-module.exports = {
-  '/v1': {
-    use: [cors ()]
+module.exports = Router.extend({
+  specification: {
+    '/v1': {
+      use: [cors ()]
+    }
   }
-};
+});

--- a/blueprint-experiences/app/seeds/mongodb/$default.js
+++ b/blueprint-experiences/app/seeds/mongodb/$default.js
@@ -6,21 +6,26 @@ module.exports = Seed.extend ({
     return {
       users: [
         {firstName: 'Ali', lastName: 'Albert', role: ['host', 'visitor']},
-        {firstName: 'Bella', lastName: 'Bulma', role: ['visitor']},
-        {firstName: 'Delhi', lastName: 'Dhowry', role: ['host', 'visitor']},
         {firstName: 'Zoe', lastName: 'Ziran', role: ['admin']}
       ],
 
       native: [
-        {name: 'native0', email: 'native1@experiences.com', scope: ['gatekeeper.client.create']}
+        {
+          name: 'native0',
+          client_id: 'experiences-app',
+          client_secret: 'experiences-app',
+          email: 'native1@experiences.com',
+          scope: ['gatekeeper.account.create']
+        }
       ],
 
       accounts: dab.map (dab.get ('users'), ((user) => {
         return {
           _id: user._id,
           username: `${user.firstName}${user.lastName}`.toLowerCase(),
-          password: `${user.firstName}.${user.lastName}`.toLowerCase(),
-          email: `${user.firstName}.${user.lastName}@experiences.com`.toLowerCase()
+          password: `freecandy`,
+          email: `${user.firstName}.${user.lastName}@experiences.com`.toLowerCase(),
+          scope: ['gatekeeper.account.create']
         }
       })),
 
@@ -28,9 +33,20 @@ module.exports = Seed.extend ({
         return {
           client: dab.ref ('native.0'),
           account: account._id,
-          refresh_token: dab.id()
+          refresh_token: dab.id(),
+          scope: ['gatekeeper.account.created']
         }
       }),
+
+      client_tokens: [
+        {
+          client: dab.ref('native.0'),
+          account: dab.ref('accounts.0'),
+          refresh_token: dab.id(),
+          scope: ['gatekeeper.account.created']
+
+        }
+      ],
 
       experiences: [
         {

--- a/ember-experiences/app/adapters/application.js
+++ b/ember-experiences/app/adapters/application.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
-  namespace: 'api'
+  host: 'http://localhost:5000',
+  namespace: 'v1'
 });

--- a/ember-experiences/app/routes/experience.js
+++ b/ember-experiences/app/routes/experience.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import Authenticated from 'ember-cli-gatekeeper/mixins/authenticated';
 
-export default Route.extend({
+export default Route.extend(Authenticated, {
 });

--- a/ember-experiences/app/routes/experience/conversation.js
+++ b/ember-experiences/app/routes/experience/conversation.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import Authenticated from 'ember-cli-gatekeeper/mixins/authenticated';
 
-export default Route.extend({
+export default Route.extend(Authenticated, {
 });

--- a/ember-experiences/app/routes/experiences/favorites.js
+++ b/ember-experiences/app/routes/experiences/favorites.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import Authenticated from 'ember-cli-gatekeeper/mixins/authenticated';
 
-export default Route.extend({
+export default Route.extend(Authenticated, {
 });

--- a/ember-experiences/app/routes/nav-enabled/experiences.js
+++ b/ember-experiences/app/routes/nav-enabled/experiences.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import Authenticated from 'ember-cli-gatekeeper/mixins/authenticated';
 
-export default Route.extend({
+export default Route.extend(Authenticated, {
 });

--- a/ember-experiences/app/routes/nav-enabled/explore.js
+++ b/ember-experiences/app/routes/nav-enabled/explore.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import Authenticated from 'ember-cli-gatekeeper/mixins/authenticated';
 
-export default Route.extend({
+export default Route.extend(Authenticated, {
 });

--- a/ember-experiences/app/routes/nav-enabled/profile.js
+++ b/ember-experiences/app/routes/nav-enabled/profile.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import Authenticated from 'ember-cli-gatekeeper/mixins/authenticated';
 
-export default Route.extend({
+export default Route.extend(Authenticated, {
 });

--- a/ember-experiences/config/environment.js
+++ b/ember-experiences/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function(environment) {
       baseUrl: 'http://localhost:5000/gatekeeper',
   
       tokenOptions: {      
-        client_id: '59ee923e1fd71c2ae68ade62',
+        client_id: '5bf2f9f2fb18ff2b128f8ee9',
       }
     },
 

--- a/ember-experiences/config/environment.js
+++ b/ember-experiences/config/environment.js
@@ -8,8 +8,7 @@ module.exports = function(environment) {
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
-        // Here you can enable experimental features on an ember canary build
-        // e.g. 'with-controller': true
+        'ds-improved-ajax': true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
@@ -19,9 +18,11 @@ module.exports = function(environment) {
 
     gatekeeper: {
       baseUrl: 'http://localhost:5000/gatekeeper',
-  
-      tokenOptions: {      
-        client_id: '5bf2f9f2fb18ff2b128f8ee9',
+      startRoute: 'index',
+
+      tokenOptions: {
+        client_id: '5bfca76ff5d0d5fa2ddc5b15', // lookup db
+        client_secret: 'experiences-app'
       }
     },
 
@@ -37,6 +38,9 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV['ember-cli-mirage'] = {
+      enabled: false
+    }
   }
 
   if (environment === 'test') {

--- a/ember-experiences/package-lock.json
+++ b/ember-experiences/package-lock.json
@@ -1929,7 +1929,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -2039,7 +2039,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2317,7 +2317,7 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         }
@@ -3390,7 +3390,7 @@
     },
     "broccoli-clean-css": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz",
       "integrity": "sha1-nbFD2a9+CuecJuOsWpuy1yDqGfo=",
       "dev": true,
       "requires": {
@@ -3456,7 +3456,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.24.0",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
           "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
           "dev": true,
           "requires": {
@@ -4528,7 +4528,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -4539,7 +4539,7 @@
     },
     "clean-css-promise": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/clean-css-promise/-/clean-css-promise-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css-promise/-/clean-css-promise-0.1.1.tgz",
       "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
       "dev": true,
       "requires": {
@@ -4680,7 +4680,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -4885,7 +4885,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
           "dev": true
         },
@@ -7892,7 +7892,7 @@
         },
         "regenerator-runtime": {
           "version": "0.9.6",
-          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
           "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
           "dev": true
         }
@@ -8161,7 +8161,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -8666,7 +8666,7 @@
     },
     "exec-file-sync": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.2.tgz",
       "integrity": "sha1-WNRB20bkDebR8w3lvgInhb2J4yg=",
       "dev": true,
       "requires": {
@@ -9078,7 +9078,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -9315,7 +9315,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.30.0",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
@@ -11428,7 +11428,7 @@
     },
     "istextorbinary": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
       "dev": true,
       "requires": {
@@ -11532,7 +11532,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
@@ -16619,7 +16619,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -16675,7 +16675,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -16995,7 +16995,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -17717,7 +17717,7 @@
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -17819,7 +17819,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -18667,7 +18667,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -18771,7 +18771,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
           "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=",
           "dev": true
         },
@@ -18792,7 +18792,7 @@
         },
         "source-map": {
           "version": "0.1.43",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
@@ -18948,7 +18948,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -19048,7 +19048,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -19117,7 +19117,7 @@
     },
     "symlink-or-copy": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
       "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg==",
       "dev": true
     },
@@ -20044,7 +20044,7 @@
     },
     "user-info": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/user-info/-/user-info-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/user-info/-/user-info-1.0.0.tgz",
       "integrity": "sha1-gcgrftY+Z0wkdWZ2U0E7PHb94jk=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Things to note:
1. The gatekeeper `client_id` changes based on the seeded data. Take a look at `gatekeeper.clients` in the database to retrieve this `id` upon restart of the api server application.

2. The `baseUrl` for gatekeeper need not be versioned. `http://localhost:5000/gatekeeper` works fine.

3. I specified a `startRoute`, according to the specifications in the documentation. I set it to `index`, but this is redundant since the module tries to route to index by default. I wanted to force a redirect from `/sign-in` to `index`. But that did not work. Hence issue #35 .

4. I did not test the `/sign-up` route.